### PR TITLE
Changed relative paths of some resources to work with nginx's reverse proxy settings

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -3,12 +3,12 @@
     "short_name": "MQT DDVis",
     "icons": [
         {
-            "src": "/android-chrome-192x192.png",
+            "src": "./android-chrome-192x192.png",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "/android-chrome-512x512.png",
+            "src": "./android-chrome-512x512.png",
             "sizes": "512x512",
             "type": "image/png"
         }

--- a/public/views/simulation.html
+++ b/public/views/simulation.html
@@ -1,5 +1,5 @@
-<link rel="stylesheet" href="../stylesheets/simulation.css"/>
-<script src="../javascripts/simulation.js"></script>
+<link rel="stylesheet" href="./stylesheets/simulation.css"/>
+<script src="./javascripts/simulation.js"></script>
 
 <div style="width: 100%">
 <div id="algo_div" class="algo-div">
@@ -72,7 +72,7 @@ An algorithm can be loaded in the following ways:
 <ul>
     <li>
         <b>Colored</b>: When ticked (default), the phase of edge weights in the decision diagram is color-coded according to the following HLS color wheel.<br>
-        <img class="colorwheel" src="../assets/hls_colorwheel.svg" alt="HLS color wheel"><br>
+        <img class="colorwheel" src="./assets/hls_colorwheel.svg" alt="HLS color wheel"><br>
         When not ticked, edges whose weight is not equal to $1$ will be displayed dashed.
     </li>
     <li>

--- a/public/views/verification.html
+++ b/public/views/verification.html
@@ -1,5 +1,5 @@
-<link rel="stylesheet" href="../stylesheets/verification.css"/>
-<script src="../javascripts/verification.js"></script>
+<link rel="stylesheet" href="./stylesheets/verification.css"/>
+<script src="./javascripts/verification.js"></script>
 <div style="width: 100%">
 <div id="ver1_algo_div" class="algo-div">
     <h3>Algorithm 1</h3>
@@ -86,7 +86,7 @@
 <ul>
     <li>
         <b>Colored</b>: When ticked (default), the phase of edge weights in the decision diagram is color-coded according to the following HLS color wheel.<br>
-        <img class="colorwheel" src="../assets/hls_colorwheel.svg" alt="HLS color wheel"><br>
+        <img class="colorwheel" src="./assets/hls_colorwheel.svg" alt="HLS color wheel"><br>
         When not ticked, edges whose weight is not equal to 1 will be displayed dashed.
     </li>
     <li>


### PR DESCRIPTION
When we are trying to host the application on our webserver with `nginx`, the reverse proxy has issues with the correct path forwarding. There is probably a way of setting up `nginx` that fixes this issue but I'm not familiar with it (any help would be appreciated!).

This PR circumvents the issue by fixing the relative resource paths to the ones that `nginx` expects. It might not be the cleanliest solution but it's the only one we have right now...