### PR TITLE
Pinned Version for hpcc-js and Export fix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - pin-version
 
 env:
   DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - pin-version
 
 env:
   DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}

--- a/public/index.html
+++ b/public/index.html
@@ -45,7 +45,7 @@
         });
     </script>
     <script src="https://d3js.org/d3.v5.min.js"></script>
-    <script src="https://unpkg.com/@hpcc-js/wasm/dist/index.min.js"></script>
+    <script src="https://unpkg.com/@hpcc-js/wasm@1.20.1/dist/index.min.js"></script>
     <script src="https://unpkg.com/d3-graphviz@3.1.0/build/d3-graphviz.js"></script>
 
     <script src="./javascripts/highlighting.js"></script>


### PR DESCRIPTION
Pin version for hpcc-js since this fails since the last update.

- [x] Pull in the new QFR with fix Export in dd_package.
- [x] Remove the PR branch from the branches that trigger deployment

This should fix #105 