### PR TITLE
🐛 Fix Amplitudes Display and Zoom Reset Bug

### DIFF
--- a/public/javascripts/simulation.js
+++ b/public/javascripts/simulation.js
@@ -950,9 +950,11 @@ function plotAmplitudes(amplitudes) {
         );
     }
 
-    amp_plot
-      .selectAll("rect")
-      .on("mouseover", function (d, i) {
+    let rect = amp_plot.selectAll("rect");
+    rect
+      .on("mouseover", function (event, d) {
+        const e = rect.nodes();
+        const i = e.indexOf(event.currentTarget);
         amp_tooltip.html(
           "State: " +
             i.toString(2).padStart(Math.log2(namps), "0") +
@@ -965,10 +967,10 @@ function plotAmplitudes(amplitudes) {
         );
         return amp_tooltip.style("visibility", "visible");
       })
-      .on("mousemove", function () {
+      .on("mousemove", function (event) {
         return amp_tooltip
-          .style("top", d3.event.pageY - 10 + "px")
-          .style("left", d3.event.pageX + 10 + "px");
+          .style("top", event.pageY - 10 + "px")
+          .style("left", event.pageX + 10 + "px");
       })
       .on("mouseout", function () {
         return amp_tooltip.style("visibility", "hidden");

--- a/public/javascripts/simulation.js
+++ b/public/javascripts/simulation.js
@@ -751,7 +751,7 @@ function print(dd, callback, resetZoom = false) {
     }
     plotAmplitudes(dd.amplitudes);
   } else {
-    qdd_div.html(qdd_text);
+    graphviz.renderDot("digraph {}");
     amp_svg.style("visibility", "hidden");
     amp_descr.style("visibility", "hidden");
     if (callback) callback();

--- a/public/javascripts/verification.js
+++ b/public/javascripts/verification.js
@@ -269,7 +269,7 @@ function ver_print(dd, callback, resetZoom = false) {
         .on("transitionStart", callback);
     }
   } else {
-    ver_qdd_div.html(ver_qdd_text);
+    ver_graphviz.renderDot("digraph {}");
     if (callback) callback();
   }
 }


### PR DESCRIPTION
The display of the amplitudes vector on the simulation page was silently broken due one of the major D3 updates that introduced quite some breaking changes. This PR fixes the underlying issue by accommodating the newer interface.

Furthermore, this PR fixes a strange bug that's been around forever: When resetting the algorithm, the DD area stopped being zoomable.

Fixes #1