### PR TITLE
Make Measurement Dialog Centered in the Window

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,10 @@
 
     <link rel="stylesheet" href="./stylesheets/style.css" />
     <link rel="stylesheet" href="./stylesheets/algo_area.css" />
+    <link
+      rel="stylesheet"
+      href="//code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css"
+    />
 
     <script
       src="https://code.jquery.com/jquery-3.6.3.min.js"

--- a/public/javascripts/simulation.js
+++ b/public/javascripts/simulation.js
@@ -548,7 +548,7 @@ function _startDialog(dialog, title, text, pzero, pone) {
     resizable: false,
     autoOpen: true,
     modal: true,
-    position: { my: "center", at: "center", of: "#algo_div" },
+    position: { my: "center", at: "center", of: window },
     width: $(algo_div).width() * 0.9,
     buttons: {
       "Option 0": {

--- a/public/javascripts/simulation.js
+++ b/public/javascripts/simulation.js
@@ -526,7 +526,7 @@ function _resizeDialog(dialog, pzero, pone) {
       dialog.dialog("option", "position", {
         my: "center",
         at: "center",
-        of: "#algo_div",
+        of: window,
       });
       dialog.dialog("option", "width", $(window).width() * 0.15);
       let dialogWidth = dialog.innerWidth();


### PR DESCRIPTION
This PR makes the measurement dialog centered relative to the window.

(Technically, this is the default setting for position. For the sake of being explicit, I'd like to keep it.)